### PR TITLE
JSONField default should be a callable instead of an instance so that…

### DIFF
--- a/games/migrations/0004_huntingofsnarkgame_extra.py
+++ b/games/migrations/0004_huntingofsnarkgame_extra.py
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='huntingofsnarkgame',
             name='extra',
-            field=django.db.models.JSONField(default={}),
+            field=django.db.models.JSONField(default=dict),
         ),
     ]

--- a/games/models.py
+++ b/games/models.py
@@ -30,7 +30,7 @@ class HuntingOfSnarkGame(TimeStampedModel):
         validators=[MinValueValidator(1), MaxValueValidator(50)],
     )
     criteria = models.ManyToManyField('games.HuntingOfSnarkCriteria')
-    extra = JSONField(default=dict())
+    extra = JSONField(default=dict)
 
     class Meta:
         ordering = ('-created',)


### PR DESCRIPTION
… it's not shared between all field instances.