### PR TITLE
Logging out via GET requests to the built-in logout view is deprecated. Use POST requests instead

### DIFF
--- a/desparchado/static/sass/main.sass
+++ b/desparchado/static/sass/main.sass
@@ -29,6 +29,14 @@ body
   line-height: 1.5
   font-size: 20px
 
+#logout-form
+  display: inline
+
+  button
+    background: none
+    border: none
+    cursor: pointer
+
 .card
   border-radius: 0
   height: 100%
@@ -326,13 +334,12 @@ body
 .top-nav
   background-color: $secondary-color
   li
-    font-size: 14px
-    color: #555
-    font-weight: 600
-    text-transform: uppercase
-    letter-spacing: 1px
-    a
+    a, button
+      font-size: 14px
       color: #555
+      font-weight: 600
+      text-transform: uppercase
+      letter-spacing: 1px
       padding: 4px 10px
       text-decoration: none
       display: block

--- a/desparchado/templates/layout/_header.html
+++ b/desparchado/templates/layout/_header.html
@@ -31,10 +31,13 @@
         </a>
       </li>
       <li class="nav-item">
-        <a href="{% url 'logout' %}" class="nav-link link-dark px-2">
-          <i class="fas fa-sign-out-alt"></i>
-          Salir
-        </a>
+        <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
+          {% csrf_token %}
+          <button type="submit" class="nav-link link-dark px-2">
+            <i class="fas fa-sign-out-alt"></i>
+            Salir
+          </button>
+        </form>
       </li>
     {% else %}
       <li class="nav-item">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated navigation styling for a cleaner, more consistent appearance across links and buttons.
  - Improved the logout button design, ensuring a seamless, inline display with enhanced visual clarity.
- **Refactor**
  - Modified the logout process to use a secure form submission instead of a link, aligning with best practice standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->