### PR TITLE
[FIX][NA] Ignore case when comparing to event description in events sync

### DIFF
--- a/dashboard/services/filbo.py
+++ b/dashboard/services/filbo.py
@@ -47,8 +47,8 @@ def get_speakers(participants, speakers_map, event_title, event_description, req
 
         if (
             speaker_record['FILBO_NAME'] in participants or
-            speaker_record['FILBO_NAME'] in event_description or
-            speaker_record['FILBO_NAME'] in event_title
+            speaker_record['FILBO_NAME'].lower() in event_description.lower() or
+            speaker_record['FILBO_NAME'].lower() in event_title.lower()
         ):
             speaker, created = Speaker.objects.get_or_create(
                 name=speaker_record['CANONICAL_NAME'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved speaker name matching in event titles and descriptions to be case-insensitive, ensuring more consistent and accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->