### PR TITLE
[FIX][TAS-85] Fixed HTML sanitizer: keep typographic whitespace

### DIFF
--- a/desparchado/tests/test_utils_sanitize_html.py
+++ b/desparchado/tests/test_utils_sanitize_html.py
@@ -3,8 +3,12 @@ import pytest
 from ..utils import sanitize_html
 
 
-@pytest.mark.parametrize('input,output', [
+@pytest.mark.parametrize('input_html,output_html', [
     ('Line 1\nLine2', 'Line 1\nLine2'),
+    ('Line 1\r\nLine2', 'Line 1\r\nLine2'),
+    ('Line 1<br>Line2', 'Line 1<br>Line2'),
+    ('Line 1<p>Line2</p>', 'Line 1<p>Line2</p>'),
+    ('Line 1    Line2', 'Line 1    Line2'),
 ])
 def test_do_not_remove_linebreaks(input_html, output_html):
     assert sanitize_html(input_html) == output_html

--- a/desparchado/tests/test_utils_sanitize_html.py
+++ b/desparchado/tests/test_utils_sanitize_html.py
@@ -1,0 +1,10 @@
+import pytest
+
+from ..utils import sanitize_html
+
+
+@pytest.mark.parametrize('input,output', [
+    ('Line 1\nLine2', 'Line 1\nLine2'),
+])
+def test_do_not_remove_linebreaks(input, output):
+    assert sanitize_html(input) == output

--- a/desparchado/tests/test_utils_sanitize_html.py
+++ b/desparchado/tests/test_utils_sanitize_html.py
@@ -6,5 +6,5 @@ from ..utils import sanitize_html
 @pytest.mark.parametrize('input,output', [
     ('Line 1\nLine2', 'Line 1\nLine2'),
 ])
-def test_do_not_remove_linebreaks(input, output):
-    assert sanitize_html(input) == output
+def test_do_not_remove_linebreaks(input_html, output_html):
+    assert sanitize_html(input_html) == output_html

--- a/desparchado/utils.py
+++ b/desparchado/utils.py
@@ -53,6 +53,4 @@ def send_notification(request, obj, model_name, created):
 
 
 def sanitize_html(html: str):
-    print(html)
-    print(sanitizer.sanitize(html))
     return sanitizer.sanitize(html)

--- a/desparchado/utils.py
+++ b/desparchado/utils.py
@@ -5,7 +5,9 @@ from django.core.mail import send_mail
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
-sanitizer = Sanitizer()
+sanitizer = Sanitizer({
+    'keep_typographic_whitespace': True,
+})
 
 
 def send_admin_notification(request, obj, form, change):
@@ -50,5 +52,7 @@ def send_notification(request, obj, model_name, created):
         logger.error('No se pudo enviar correo electrónico')
 
 
-def strip_html_tags(html: str):
+def sanitize_html(html: str):
+    print(html)
+    print(sanitizer.sanitize(html))
     return sanitizer.sanitize(html)

--- a/events/forms.py
+++ b/events/forms.py
@@ -6,7 +6,7 @@ from crispy_forms.layout import Submit, Layout, Div, HTML, Field
 from crispy_forms.bootstrap import PrependedText
 from crispy_bootstrap5.bootstrap5 import Switch
 from dal import autocomplete
-from desparchado.utils import strip_html_tags
+from desparchado.utils import sanitize_html
 
 from .models import Event, Organizer, Speaker
 
@@ -32,7 +32,7 @@ class EventBaseForm(forms.ModelForm):
                   'o posterior a la fecha de inicio.'
             self.add_error('event_end_date', msg)
 
-        cleaned_data['description'] = strip_html_tags(cleaned_data.get('description', ''))
+        cleaned_data['description'] = sanitize_html(cleaned_data.get('description', ''))
 
         return cleaned_data
 
@@ -227,7 +227,7 @@ class OrganizerForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        cleaned_data['description'] = strip_html_tags(cleaned_data.get('description', ''))
+        cleaned_data['description'] = sanitize_html(cleaned_data.get('description', ''))
         return cleaned_data
 
     class Meta:
@@ -263,7 +263,7 @@ class SpeakerForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        cleaned_data['description'] = strip_html_tags(cleaned_data.get('description', ''))
+        cleaned_data['description'] = sanitize_html(cleaned_data.get('description', ''))
         return cleaned_data
 
     class Meta:

--- a/places/forms.py
+++ b/places/forms.py
@@ -5,7 +5,7 @@ from crispy_forms.layout import Submit
 from crispy_forms.layout import Layout
 from crispy_forms.layout import Div
 from mapwidgets import GoogleMapPointFieldWidget
-from desparchado.utils import strip_html_tags
+from desparchado.utils import sanitize_html
 
 from .models import Place
 
@@ -35,7 +35,7 @@ class PlaceForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        cleaned_data['description'] = strip_html_tags(cleaned_data.get('description', ''))
+        cleaned_data['description'] = sanitize_html(cleaned_data.get('description', ''))
         return cleaned_data
 
     class Meta:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved HTML sanitization for description fields in event and place forms, preserving line breaks and typographic whitespace.

- **Bug Fixes**
  - Ensured that line breaks are retained in sanitized descriptions.

- **Tests**
  - Added tests to verify that line breaks are not removed during HTML sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->