### PR TITLE
[FIX][NA] Do not include Bootstrap styles in redesigned templates

### DIFF
--- a/desparchado/templates/desparchado/home.html
+++ b/desparchado/templates/desparchado/home.html
@@ -1,10 +1,11 @@
 {% extends 'layout/base.html' %}
 {% load i18n humanize desparchado_tags django_vite %}
 
+{% block bootstrap_css %}{% endblock %}
+
 {% block extra_scripts %}
   {% vite_asset 'desparchado/frontend/scripts/home.ts' %}
 {% endblock extra_scripts %}
-
 
 {% block content %}
   <div class="intro-section">

--- a/desparchado/templates/layout/base.html
+++ b/desparchado/templates/layout/base.html
@@ -23,17 +23,17 @@
     <meta name="news_keywords" content="Eventos" />
     <meta name="google-site-verification" content="fzaFpFH8Q6VYOrIz3z98OPuzP8J99Cty7ic_jb9ApJo" />
 
+  {% block bootstrap_css %}
     <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-
     <!-- Fortawesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  {% endblock %}
 
     {# This will add a <script> tag to include the ViteJS HMR client. #}
     {# This tag will include this script only if DJANGO_VITE_DEV_MODE is true, otherwise this will do nothing. #}
     {% vite_hmr_client %}
 
-    {% vite_asset 'desparchado/static/ts/old_main.ts' %}
     {% vite_asset 'desparchado/frontend/scripts/mount-vue.ts' %}
 
     <!-- Select 2 Bootstrap 5 theme-->

--- a/events/templates/events/event_detail.html
+++ b/events/templates/events/event_detail.html
@@ -3,6 +3,8 @@
 
 {% block title %}{{ event.title }}{% endblock %}
 
+{% block bootstrap_css %}{% endblock %}
+
 {% block meta %}
   <meta property="og:title" content="{{ event.title }}">
   <meta property="og:description" content="{{ event.place }}">

--- a/events/templates/events/event_list.html
+++ b/events/templates/events/event_list.html
@@ -3,6 +3,8 @@
 
 {% block title %}{% translate 'Eventos' %}{% endblock %}
 
+{% block bootstrap_css %}{% endblock %}
+
 {% block content %}
   <h1>{% translate 'Eventos' %}</h1>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added hooks for page-specific Bootstrap CSS, enabling per-page style overrides without changing global styles.

- Refactor
  - Centralized CSS includes in the base layout within an overridable section for consistent, flexible styling control.

- Chores
  - Updated the frontend asset entry point used to initialize the app.

No immediate visual changes are expected; these updates improve styling extensibility and asset loading for future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->