### PR TITLE
[FEATURE][TAS-134] Make Organizer and Speaker images mandatory on Form level

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,11 @@
 # pylint: disable=redefined-outer-name
 from datetime import timedelta
+from io import BytesIO
 
+from PIL import Image
 import pytest
 from django.utils import timezone
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from blog.tests.factories import PostFactory as BlogPostFactory
 from events.tests.factories import EventFactory, OrganizerFactory, SpeakerFactory
@@ -127,3 +130,14 @@ def special(event, not_published_event, not_approved_event):
     return SpecialFactory(
         related_events=[event, not_published_event, not_approved_event],
     )
+
+
+@pytest.fixture
+def image():
+    """Return a mock uploaded PNG image for tests."""
+    img = Image.new("RGBA", size=(50, 50), color=(155, 0, 0))
+    buffer = BytesIO()
+    img.save(buffer, format="PNG")
+    buffer.seek(0)
+
+    return ('test.png', buffer.read(), 'image/png')

--- a/conftest.py
+++ b/conftest.py
@@ -2,10 +2,9 @@
 from datetime import timedelta
 from io import BytesIO
 
-from PIL import Image
 import pytest
 from django.utils import timezone
-from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
 
 from blog.tests.factories import PostFactory as BlogPostFactory
 from events.tests.factories import EventFactory, OrganizerFactory, SpeakerFactory

--- a/desparchado/tests/test_utils_sanitize_html.py
+++ b/desparchado/tests/test_utils_sanitize_html.py
@@ -4,13 +4,17 @@ from ..utils import sanitize_html
 
 
 @pytest.mark.parametrize(
-    'input_html,output_html',
+    "input_html,output_html",
     [
-        ('Line 1\nLine 2', 'Line 1\nLine 2'),
-        ('Line 1\r\nLine 2', 'Line 1\r\nLine 2'),
-        ('Line 1<br>Line 2', 'Line 1<br>Line 2'),
-        ('Line 1<p>Line 2</p>', 'Line 1<p>Line 2</p>'),
-        ('Line 1    Line 2', 'Line 1    Line 2'),
+        ("Line 1\nLine 2", "Line 1\nLine 2"),
+        ("Line 1\r\nLine 2", "Line 1\r\nLine 2"),
+        ("Line 1<br>Line 2", "Line 1<br>Line 2"),
+        ("Line 1<p>Line 2</p>", "Line 1<p>Line 2</p>"),
+        ("Line 1    Line 2", "Line 1    Line 2"),
+        ("Line 1\n\nLine 2", "Line 1\n\nLine 2"),
+        ("Line 1 \nLine 2", "Line 1 \nLine 2"),
+        ("Line 1\n Line 2", "Line 1\n Line 2"),
+        ('<p class="red">Line</p>', "<p>Line</p>"),
     ],
 )
 def test_do_not_remove_linebreaks(input_html, output_html):

--- a/desparchado/tests/test_utils_sanitize_html.py
+++ b/desparchado/tests/test_utils_sanitize_html.py
@@ -6,11 +6,11 @@ from ..utils import sanitize_html
 @pytest.mark.parametrize(
     'input_html,output_html',
     [
-        ('Line 1\nLine2', 'Line 1\nLine2'),
-        ('Line 1\r\nLine2', 'Line 1\r\nLine2'),
-        ('Line 1<br>Line2', 'Line 1<br>Line2'),
-        ('Line 1<p>Line2</p>', 'Line 1<p>Line2</p>'),
-        ('Line 1    Line2', 'Line 1    Line2'),
+        ('Line 1\nLine 2', 'Line 1\nLine 2'),
+        ('Line 1\r\nLine 2', 'Line 1\r\nLine 2'),
+        ('Line 1<br>Line 2', 'Line 1<br>Line 2'),
+        ('Line 1<p>Line 2</p>', 'Line 1<p>Line 2</p>'),
+        ('Line 1    Line 2', 'Line 1    Line 2'),
     ],
 )
 def test_do_not_remove_linebreaks(input_html, output_html):

--- a/events/forms.py
+++ b/events/forms.py
@@ -223,6 +223,8 @@ class SpeakerForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.fields["image"].required = True
+
         self.helper = FormHelper()
         self.helper.form_id = 'speaker_form'
         self.helper.form_method = 'post'

--- a/events/forms.py
+++ b/events/forms.py
@@ -174,6 +174,8 @@ class OrganizerForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.fields["image"].required = True
+
         self.helper = FormHelper()
         self.helper.form_id = 'organizer_form'
         self.helper.form_method = 'post'

--- a/events/models/event.py
+++ b/events/models/event.py
@@ -77,7 +77,7 @@ class Event(TimeStampedModel):
         'events.Organizer',
         verbose_name='Organizadores',
         related_name='events',
-        help_text='Por , asegúrate de que el/la organizador/a '
+        help_text='Por favor, asegúrate de que el/la organizador/a '
                   'que deseas asignar al evento no exista en nuestro sistema '
                   'antes de crearlo/a.',
     )

--- a/events/tests/factories.py
+++ b/events/tests/factories.py
@@ -11,6 +11,7 @@ from ..models import Event, Organizer, Speaker
 class SpeakerFactory(factory.django.DjangoModelFactory):
     name = factory.Faker('name')
     description = factory.Faker('text')
+    image = factory.django.ImageField()
     created_by = factory.SubFactory(UserFactory)
 
     class Meta:

--- a/events/tests/factories.py
+++ b/events/tests/factories.py
@@ -21,6 +21,7 @@ class SpeakerFactory(factory.django.DjangoModelFactory):
 class OrganizerFactory(factory.django.DjangoModelFactory):
     name = factory.Faker('company')
     description = factory.Faker('text')
+    image = factory.django.ImageField()
     website_url = 'https://example.com'
     created_by = factory.SubFactory(UserFactory)
 

--- a/events/tests/views/test_organizer_create.py
+++ b/events/tests/views/test_organizer_create.py
@@ -1,7 +1,5 @@
 import pytest
-
 from django.urls import reverse
-from django.core.files.base import ContentFile
 
 from events.models import Organizer
 

--- a/events/tests/views/test_organizer_create.py
+++ b/events/tests/views/test_organizer_create.py
@@ -1,5 +1,7 @@
 import pytest
+
 from django.urls import reverse
+from django.core.files.base import ContentFile
 
 from events.models import Organizer
 
@@ -12,7 +14,7 @@ def test_non_authenticated_user_cannot_create_organizer(django_app):
 
 
 @pytest.mark.django_db
-def test_successfully_create_organizer(django_app, user):
+def test_successfully_create_organizer(django_app, user, image):
     organizers_count = Organizer.objects.count()
 
     response = django_app.get(
@@ -23,6 +25,7 @@ def test_successfully_create_organizer(django_app, user):
 
     form = response.forms['organizer_form']
     form['name'] = 'Librería LERNER'
+    form['image'] = image
     form['description'] = 'Librería LERNER'
     form['website_url'] = 'https://www.librerialerner.com.co/'
 

--- a/events/tests/views/test_speaker_create.py
+++ b/events/tests/views/test_speaker_create.py
@@ -12,7 +12,7 @@ def test_non_authenticated_user_cannot_create_speaker(django_app):
 
 
 @pytest.mark.django_db
-def test_successfully_create_speaker(django_app, user):
+def test_successfully_create_speaker(django_app, user, image):
     speakers_count = Speaker.objects.count()
 
     response = django_app.get(reverse(VIEW_NAME), user=user, status=200)
@@ -20,6 +20,7 @@ def test_successfully_create_speaker(django_app, user):
     form = response.forms['speaker_form']
     form['name'] = 'Julian Barnes'
     form['description'] = 'English writer'
+    form['image'] = image
 
     response = form.submit()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image upload is now required when creating organizers and speakers; forms will validate and prompt if missing.

* **Tests**
  * Added an image test fixture and updated factories/tests to include image uploads.
  * Expanded sanitize-html test coverage to cover line-break/whitespace nuances and removal of unwanted HTML attributes.

* **Documentation**
  * Fixed Spanish help text to start with “Por favor, asegúrate de que el/la organizador/a…”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->