### PR TITLE
[FEATURE][TAS-139] Show only cities with events in city filter on future events page

### DIFF
--- a/desparchado/settings/base.py
+++ b/desparchado/settings/base.py
@@ -190,7 +190,7 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "unique-snowflake",
-    }
+    },
 }
 
 LOGGING = {

--- a/desparchado/settings/base.py
+++ b/desparchado/settings/base.py
@@ -186,6 +186,13 @@ STATICFILES_FINDERS = (
 
 SITE_ID = 1
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "unique-snowflake",
+    }
+}
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/desparchado/settings/test.py
+++ b/desparchado/settings/test.py
@@ -8,7 +8,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-    }
+    },
 }
 
 LOGGING['root']['handlers'] = ['console']   # noqa: F405

--- a/desparchado/settings/test.py
+++ b/desparchado/settings/test.py
@@ -5,6 +5,12 @@ DEBUG = True
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    }
+}
+
 LOGGING['root']['handlers'] = ['console']   # noqa: F405
 
 # Indicates whether to serve assets via the ViteJS development server

--- a/events/views.py
+++ b/events/views.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlencode
 
+from django.core.cache import cache
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.postgres.search import SearchQuery, SearchVector
 from django.db.models import Q
@@ -57,7 +58,6 @@ class EventListBaseView(ListView):
         context['category_filter_name'] = self.category_filter_name
         context['category_filter_value'] = self.category_filter_value
         context['category_choices'] = Event.Category.choices
-        context['cities'] = City.objects.all()
 
         params = {}
         if self.search_query_value:
@@ -108,6 +108,20 @@ class EventListView(EventListBaseView):
     def get_queryset(self):
         return super().get_queryset().future()
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        if 'city_filter_ids' in cache:
+            city_ids = cache.get('city_filter_ids')
+        else:
+            events = context[self.context_object_name]
+            city_ids = events.values_list("place__city_id", flat=True)
+            cache.set('city_filter_ids', city_ids, 24 * 60 * 60)
+
+        context['cities'] = City.objects.filter(id__in=city_ids)
+
+        return context
+
 class PastEventListView(EventListBaseView):
     template_name = "events/past_event_list.html"
     year_filter_name = 'year'
@@ -139,6 +153,7 @@ class PastEventListView(EventListBaseView):
         context = super().get_context_data(**kwargs)
 
         # For search form rendering
+        context["cities"] = City.objects.all()
         context['year_filter_name'] = self.year_filter_name
         context['year_filter_value'] = self.year_filter_value
         context['year_range'] = self.year_range

--- a/events/views.py
+++ b/events/views.py
@@ -114,7 +114,7 @@ class EventListView(EventListBaseView):
         if 'city_filter_ids' in cache:
             city_ids = cache.get('city_filter_ids')
         else:
-            events = context[self.context_object_name]
+            events = self.get_queryset()
             city_ids = events.values_list("place__city_id", flat=True)
             cache.set('city_filter_ids', city_ids, 24 * 60 * 60)
 

--- a/events/views.py
+++ b/events/views.py
@@ -1,8 +1,8 @@
 from urllib.parse import urlencode
 
-from django.core.cache import cache
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.postgres.search import SearchQuery, SearchVector
+from django.core.cache import cache
 from django.db.models import Q
 from django.http import JsonResponse
 from django.urls import reverse


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Event list shows city filters relevant to events on the current page; past events list keeps year filter across pages and includes city options for search.

* Bug Fixes
  * Preserves year filter parameters when navigating pagination in past events.

* Chores
  * Added application caching configuration to improve performance.

* Tests
  * Added test cache configuration and adjusted test logging to output to console.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->