### PR TITLE
[FEATURE][NA] Set event source URL on event detail page

### DIFF
--- a/desparchado/frontend/components/presentational/atoms/button/Button.vue
+++ b/desparchado/frontend/components/presentational/atoms/button/Button.vue
@@ -2,6 +2,7 @@
   <component
     :is="link ? 'a' : 'button'"
     :href="link"
+    :target="link && props.target ? props.target : undefined"
     :type="link ? undefined : isActionSubmit ? 'submit' : ''"
     :aria-label="!label && props.name ? props.name : undefined"
     :class="[
@@ -82,6 +83,7 @@
     radius?: ButtonRadius;
     customClass?: string;
     link?: string;
+    target?: '_blank' | '_self' | '_parent' | '_top';
     onClick?: () => void;
     actionId?: string;
     isActionSubmit?: boolean;

--- a/desparchado/frontend/components/presentational/atoms/button/Button.vue
+++ b/desparchado/frontend/components/presentational/atoms/button/Button.vue
@@ -3,13 +3,14 @@
     :is="link ? 'a' : 'button'"
     :href="link"
     :target="link && props.target ? props.target : undefined"
+    :rel="link && props.target === '_blank' ? 'noopener noreferrer' : undefined"
     :type="link ? undefined : isActionSubmit ? 'submit' : ''"
     :aria-label="!label && props.name ? props.name : undefined"
     :class="[
       bem(baseClass),
       types[props.type],
       paddings[props.padding],
-      radiuses[props.radius],
+      radiuses[props.radius],fv
       props.customClass,
     ]"
     :style="props.name && `--button-name: '${props.name}'`"

--- a/events/templates/events/event_detail.html
+++ b/events/templates/events/event_detail.html
@@ -113,7 +113,7 @@
               data-vue-prop-type="secondary"
               data-vue-prop-label="{% translate 'Ir al sitio del evento' %}"
               data-vue-prop-icon="world-40"
-              data-vue-prop-link="{{ event.get_absolute_url }}"
+              data-vue-prop-link="{{ event.event_source_url }}"
             >
             </div>
           </div>
@@ -238,7 +238,7 @@
           data-vue-prop-name="Ir al sitio del evento"
           data-vue-prop-icon="world-40"
           data-vue-prop-padding="balanced"
-          data-vue-prop-link="{{ event.get_absolute_url }}"
+          data-vue-prop-link="{{ event.event_source_url }}"
         >
         </div>
       </div>

--- a/events/templates/events/event_detail.html
+++ b/events/templates/events/event_detail.html
@@ -114,6 +114,7 @@
               data-vue-prop-label="{% translate 'Ir al sitio del evento' %}"
               data-vue-prop-icon="world-40"
               data-vue-prop-link="{{ event.event_source_url }}"
+              data-vue-prop-target="_blank"
             >
             </div>
           </div>
@@ -239,6 +240,7 @@
           data-vue-prop-icon="world-40"
           data-vue-prop-padding="balanced"
           data-vue-prop-link="{{ event.event_source_url }}"
+          data-vue-prop-target="_blank"
         >
         </div>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Ir al sitio del evento” buttons (mobile and main actions) now open the event’s external source URL instead of the internal event page.
  * These buttons now open the external site in a new browser tab for a smoother experience.
  * Link buttons support specifying the link target, and external links opened in a new tab use safer link handling (noopener/noreferrer).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->