### PR TITLE
[FEATURE][TAS-150] Save organizers from spreadsheet

### DIFF
--- a/dashboard/templates/dashboard/spreadsheet_sync/form.html
+++ b/dashboard/templates/dashboard/spreadsheet_sync/form.html
@@ -35,6 +35,7 @@
               <th>{% translate 'Evento' %}</th>
               <th>{% translate 'Creado' %}</th>
               <th>{% translate 'Error' %}</th>
+              <th>{% translate 'Advertencias' %}</th>
             </tr>
           </thead>
           <tbody>
@@ -53,6 +54,7 @@
                 {% endif %}
               </td>
               <td>{{ event_data.error }}</td>
+              <td>{{ event_data.warnings|join:" // " }}</td>
             </tr>
           {% endfor %}
           </tbody>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events can now have multiple organizers when imported from spreadsheets using comma-separated names; valid organizers are linked and event creation proceeds.
* **UI**
  * Import results table now shows a new "Warnings" column with per-row messages for any unrecognized organizer names, improving import feedback without blocking processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->