### PR TITLE
[FEATURE][NA] Show image previews in admin

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -124,12 +124,17 @@ class EventAdmin(admin.ModelAdmin):
 
     @admin.display(description='Imagen')
     def image_preview(self, obj):
-        return format_html(f'<img height="100" src="{obj.get_image_url()}" />')
+        return format_html(
+            '<img height="100" src="{}" />',
+            obj.get_image_url()
+        )
 
     @admin.display(description="URL")
     def source_url_display(self, obj):
-        return format_html(f'<a target="_blank" href="{obj.event_source_url}">URL</a>')
-
+        return format_html(
+            '<a target="_blank" href="{}">URL</a>',
+            obj.event_source_url
+        )
     @admin.display(description="Organizadores")
     def get_organizers(self, obj):
         return "\n".join([o.name for o in obj.organizers.all()])

--- a/events/admin.py
+++ b/events/admin.py
@@ -126,14 +126,14 @@ class EventAdmin(admin.ModelAdmin):
     def image_preview(self, obj):
         return format_html(
             '<img height="100" src="{}" />',
-            obj.get_image_url()
+            obj.get_image_url(),
         )
 
     @admin.display(description="URL")
     def source_url_display(self, obj):
         return format_html(
             '<a target="_blank" href="{}">URL</a>',
-            obj.event_source_url
+            obj.event_source_url,
         )
     @admin.display(description="Organizadores")
     def get_organizers(self, obj):

--- a/events/admin.py
+++ b/events/admin.py
@@ -265,7 +265,7 @@ class SpeakerAdmin(admin.ModelAdmin):
     raw_id_fields = ('editors',)
 
     def image_preview(self, obj):
-        return format_html(f'<img height="70" src="{obj.get_image_url()}" />')
+        return format_html('<img height="70" src="{}" />', obj.get_image_url())
     image_preview.short_description = 'Image'
 
     def save_model(self, request, obj, form, change):

--- a/events/admin.py
+++ b/events/admin.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib import admin
 from django.shortcuts import redirect, render
 from django.utils.translation import gettext_lazy as _
+from django.utils.html import format_html
 
 from desparchado.utils import send_admin_notification
 from specials.models import Special
@@ -50,6 +51,7 @@ class EventAdmin(admin.ModelAdmin):
         'is_published',
         'is_approved',
         'is_hidden',
+        'image_preview',
         'category',
         'description',
         'source_id',
@@ -115,6 +117,10 @@ class EventAdmin(admin.ModelAdmin):
     )
     actions = ['update_category']
 
+    def image_preview(self, obj):
+        return format_html(f'<img height="100" src="{obj.get_image_url()}" />')
+    image_preview.short_description = 'Image'
+
     def update_category(self, request, queryset):
         form = None
 
@@ -165,12 +171,24 @@ class EventAdmin(admin.ModelAdmin):
 
 @admin.register(Organizer)
 class OrganizerAdmin(admin.ModelAdmin):
-    list_display = ('name', 'slug', 'description', 'created_by', 'created', 'modified')
+    list_display = (
+        'name',
+        'slug',
+        'image_preview',
+        'description',
+        'created_by',
+        'created',
+        'modified'
+    )
     list_filter = ('created_by__is_superuser',)
     search_fields = ('name', 'description')
     readonly_fields = ('slug',)
     exclude = ('created_by',)
     raw_id_fields = ('editors',)
+
+    def image_preview(self, obj):
+        return format_html(f'<img height="70" src="{obj.get_image_url()}" />')
+    image_preview.short_description = 'Image'
 
     def save_model(self, request, obj, form, change):
         if not obj.id:
@@ -181,13 +199,13 @@ class OrganizerAdmin(admin.ModelAdmin):
 @admin.register(Speaker)
 class SpeakerAdmin(admin.ModelAdmin):
     list_display = (
-        'name',
-        'slug',
-        'description',
-        'image',
-        'created_by',
-        'created',
-        'modified',
+        "name",
+        "slug",
+        "description",
+        "image_preview",
+        "created_by",
+        "created",
+        "modified",
     )
     list_filter = ("created_by__is_superuser",)
     search_fields = ('name',)
@@ -220,6 +238,10 @@ class SpeakerAdmin(admin.ModelAdmin):
         ),
     )
     raw_id_fields = ('editors',)
+
+    def image_preview(self, obj):
+        return format_html(f'<img height="70" src="{obj.get_image_url()}" />')
+    image_preview.short_description = 'Image'
 
     def save_model(self, request, obj, form, change):
         if not obj.id:

--- a/events/models/event.py
+++ b/events/models/event.py
@@ -102,7 +102,7 @@ class Event(TimeStampedModel):
     )
 
     is_featured_on_homepage = models.BooleanField(
-        'Está destacado en la página principal',
+        'Está destacado en home',
         default=False,
     )
 
@@ -117,7 +117,7 @@ class Event(TimeStampedModel):
         help_text='Campo de uso exclusivo para el administrador del sitio',
     )
     is_hidden = models.BooleanField(
-        'Hidden from home and future events',
+        'Está oculto en home',
         default=False,
         help_text='Used for bulk event syncs for book fairs and festivals',
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Admin lists now show image previews for events, organizers, and speakers.
  * Event source links are clickable directly from the admin list.
  * Organizer and speaker names are displayed in event listings.
  * Added a “Last modified” column in the admin for events.

* Style
  * Updated Spanish labels: “Está destacado en home” and “Está oculto en home” for clearer wording in the admin UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->